### PR TITLE
Move scout_rsa.pub file to correct directory

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -125,7 +125,7 @@ class scoutd(
     if ($plugin_pubkey != '') {
       file { 'scout_plugin_pub_key':
         ensure  => present,
-        path    => '/var/lib/scoutd/.scout/scout_rsa.pub',
+        path    => '/var/lib/scoutd/scout_rsa.pub',
         content => $plugin_pubkey,
         owner   => 'scoutd',
         group   => 'scoutd',


### PR DESCRIPTION
I tried to use the scoutd puppet module today, but noticed that I got this error on servers where I had used custom plugins:

'The code signature failed verification. Please place your account-specific public key at /var/lib/scoutd/scout_rsa.pub.'

As far as I can tell, the Puppet module should be putting the scout_rsa.pub file in /var/lib/scoutd/ not /var/lib/scoutd/.scout.  If this is true, then we probably also don't need the /var/lib/scoutd/.scout directory.

This pull request fixes the above error. Thanks!