### PR TITLE
Set status attribute on scout service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -110,6 +110,7 @@ class scoutd(
     service { 'scout':
       ensure  => running,
       start   => 'scoutctl restart',
+      status  => 'scoutctl status | grep running',
       require => Package['scoutd']
     }
 


### PR DESCRIPTION
Without this Puppet continually restarts the scout service (at least on CentOS 6 machines).

```
May  8 03:44:58 hydrogen puppet-agent[10250]: (/Stage[main]/Scoutd/Service[scout]/ensure) ensure changed 'stopped' to 'running'
```

The "automatic process lookup" provided by the service resource, described here https://docs.puppet.com/puppet/latest/reference/type.html#service-attribute-status, doesn't seem to work for this service. `scoutctl status` returns the `running` string only when the scout service is running. As a result grep returns an exit code of 0 when the service is running and 1 when its not. This matchs the required behavior for the status command described at https://docs.puppet.com/puppet/latest/reference/type.html#service-attribute-status.
